### PR TITLE
fix issue-28474

### DIFF
--- a/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
+++ b/src/main/resources/hudson/security/LDAPSecurityRealm/config.jelly
@@ -65,7 +65,7 @@ THE SOFTWARE.
             <f:textbox autocomplete="off"/>
         </f:entry>
         <f:entry field="managerPasswordSecret" title="${%Manager Password}">
-            <f:password autocomplete="off"/>
+            <f:password autocomplete="new-password"/>
         </f:entry>
         <f:entry field="displayNameAttributeName" title="${%Display Name LDAP attribute}">
             <f:textbox default="${descriptor.DEFAULT_DISPLAYNAME_ATTRIBUTE_NAME}"/>


### PR DESCRIPTION
fix for https://issues.jenkins-ci.org/browse/JENKINS-28474.
Now `autocomplete="off"` does not work in some case.
Use `autocomplete="new-password"` will require a manually inputed new password

See:
http://stackoverflow.com/questions/15738259/disabling-chrome-autofill
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete